### PR TITLE
Bump version to 4.11.2 for Playgrounds

### DIFF
--- a/Xcode/AudioKitPlaygrounds.xcodeproj/project.pbxproj
+++ b/Xcode/AudioKitPlaygrounds.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = C46EDA461E94F04D0099E238;

--- a/Xcode/AudioKitPlaygrounds.xcodeproj/xcshareddata/xcschemes/AudioKitPlaygrounds.xcscheme
+++ b/Xcode/AudioKitPlaygrounds.xcodeproj/xcshareddata/xcschemes/AudioKitPlaygrounds.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C46EDA4F1E94F04D0099E238"
+               BuildableName = "AudioKitPlaygrounds.framework"
+               BlueprintName = "AudioKitPlaygrounds"
+               ReferencedContainer = "container:AudioKitPlaygrounds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C46EDA4F1E94F04D0099E238"
+            BuildableName = "AudioKitPlaygrounds.framework"
+            BlueprintName = "AudioKitPlaygrounds"
+            ReferencedContainer = "container:AudioKitPlaygrounds.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Xcode/Playgrounds/Analysis.playground/Pages/FFT Analysis.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/FFT Analysis.xcplaygroundpage/Contents.swift
@@ -10,8 +10,8 @@ var player = AKPlayer(audioFile: file)
 player.isLooping = true
 player.buffering = .always
 
-AudioKit.output = player
-try AudioKit.start()
+AKManager.output = player
+try AKManager.start()
 player.play()
 let fft = AKFFTTap(player)
 

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Node FFT Plot.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Node FFT Plot.xcplaygroundpage/Contents.swift
@@ -7,8 +7,8 @@ import AudioKit
 var microphone = AKMicrophone()
 
 //: Zero out the microphone to prevent feedback
-AudioKit.output = AKBooster(microphone, gain: 0.0)
-try AudioKit.start()
+AKManager.output = AKBooster(microphone, gain: 0.0)
+try AKManager.start()
 
 import AudioKitUI
 

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Node Output Plot.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Node Output Plot.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ delay.time = 0.1 // seconds
 delay.feedback = 0.9 // Normalized Value 0 - 1
 delay.dryWetMix = 0.6 // Normalized Value 0 - 1
 
-AudioKit.output = delay
-try AudioKit.start()
+AKManager.output = delay
+try AKManager.start()
 player.play()
 
 import AudioKitUI

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Output Waveform Plot.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Output Waveform Plot.xcplaygroundpage/Contents.swift
@@ -8,8 +8,8 @@ import AudioKit
 var oscillator = AKFMOscillator()
 oscillator.amplitude = 0.1
 oscillator.rampDuration = 0.1
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 oscillator.start()
 
 import AudioKitUI

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Rolling Output Plot.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Rolling Output Plot.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ player.looping = true
 var variSpeed = AKVariSpeed(player)
 variSpeed.rate = 2.0
 
-AudioKit.output = variSpeed
-try AudioKit.start()
+AKManager.output = variSpeed
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Amplitude.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Amplitude.xcplaygroundpage/Contents.swift
@@ -18,8 +18,8 @@ let oscillatorNode = AKOperationGenerator { _ in
 }
 
 let trackedAmplitude = AKAmplitudeTracker(oscillatorNode)
-AudioKit.output = trackedAmplitude
-try AudioKit.start()
+AKManager.output = trackedAmplitude
+try AKManager.start()
 oscillatorNode.start()
 
 //: User Interface

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Frequency of Audio File.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Frequency of Audio File.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ player.buffering = .always
 
 let tracker = AKFrequencyTracker(player)
 
-AudioKit.output = tracker
-try AudioKit.start()
+AKManager.output = tracker
+try AKManager.start()
 player.play()
 
 //: User Interface

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Frequency.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Frequency.xcplaygroundpage/Contents.swift
@@ -22,8 +22,8 @@ let secondaryOscillator = AKOscillator()
 
 //: The frequency tracker passes its input to the output,
 //: so we can insert into the signal chain at the bottom
-AudioKit.output = AKMixer(booster, secondaryOscillator)
-try AudioKit.start()
+AKManager.output = AKMixer(booster, secondaryOscillator)
+try AKManager.start()
 
 oscillatorNode.start()
 secondaryOscillator.start()

--- a/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Microphone Input.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Analysis.playground/Pages/Tracking Microphone Input.xcplaygroundpage/Contents.swift
@@ -21,8 +21,8 @@ let silence = AKBooster(tracker, gain: 0)
 
 //: The frequency tracker passes its input to the output,
 //: so we can insert into the signal chain at the bottom
-AudioKit.output = silence
-try AudioKit.start()
+AKManager.output = silence
+try AKManager.start()
 
 //: User Interface
 import AudioKitUI

--- a/Xcode/Playgrounds/Basics.playground/Pages/Balancing Nodes.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Balancing Nodes.xcplaygroundpage/Contents.swift
@@ -21,8 +21,8 @@ let lowPassFiltering = AKLowPassFilter(highPassFiltering, cutoffFrequency: 300)
 //: At this point you don't have much signal left, so you balance it against the original signal!
 let rebalancedWithSource = AKBalancer(lowPassFiltering, comparator: source)
 
-AudioKit.output = rebalancedWithSource
-try AudioKit.start()
+AKManager.output = rebalancedWithSource
+try AKManager.start()
 source.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Basics.playground/Pages/Connecting Nodes Part 2.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Connecting Nodes Part 2.xcplaygroundpage/Contents.swift
@@ -49,9 +49,9 @@ class AudioEngine {
         reverb = AKReverb(delay)
         reverb.loadFactoryPreset(.cathedral)
 
-        AudioKit.output = reverb
+        AKManager.output = reverb
         do {
-            try AudioKit.start()
+            try AKManager.start()
         } catch {
             AKLog("AudioKit did not start!")
         }

--- a/Xcode/Playgrounds/Basics.playground/Pages/Connecting Nodes.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Connecting Nodes.xcplaygroundpage/Contents.swift
@@ -31,8 +31,8 @@ delay.dryWetMix = 0.2 // Normalized Value 0 - 1
 let reverb = AKReverb(delay)
 reverb.loadFactoryPreset(.cathedral)
 
-AudioKit.output = reverb
-try AudioKit.start()
+AKManager.output = reverb
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Basics.playground/Pages/Dry Wet Mixer.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Dry Wet Mixer.xcplaygroundpage/Contents.swift
@@ -28,8 +28,8 @@ reverb.loadFactoryPreset(.largeChamber)
 
 let mixture = AKDryWetMixer(drums, reverb, balance: 0.5)
 
-AudioKit.output = mixture
-try AudioKit.start()
+AKManager.output = mixture
+try AKManager.start()
 drums.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Basics.playground/Pages/Introduction and Hello World.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Introduction and Hello World.xcplaygroundpage/Contents.swift
@@ -17,8 +17,8 @@ import AudioKit
 
 let oscillator = AKOscillator()
 
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 oscillator.start()
 

--- a/Xcode/Playgrounds/Basics.playground/Pages/Low-Frequency Oscillating of Parameters.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Low-Frequency Oscillating of Parameters.xcplaygroundpage/Contents.swift
@@ -26,8 +26,8 @@ let generator = AKOperationGenerator { _ in
         amplitude: 0.2)
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 
 generator.start()
 

--- a/Xcode/Playgrounds/Basics.playground/Pages/Metronome.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Metronome.xcplaygroundpage/Contents.swift
@@ -24,8 +24,8 @@ metronome.callback = {
     }
 }
 
-AudioKit.output = metronome
-try AudioKit.start()
+AKManager.output = metronome
+try AKManager.start()
 metronome.start()
 
 import AudioKitUI

--- a/Xcode/Playgrounds/Basics.playground/Pages/Mixing Nodes.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Mixing Nodes.xcplaygroundpage/Contents.swift
@@ -30,8 +30,8 @@ lead.buffering = .always
 //: Any number of inputs can be summed into one output
 let mixer = AKMixer(drums, bass, guitar, lead)
 let booster = AKBooster(mixer)
-AudioKit.output = booster
-try AudioKit.start()
+AKManager.output = booster
+try AKManager.start()
 
 drums.play()
 bass.play()

--- a/Xcode/Playgrounds/Basics.playground/Pages/Parameter Ramping.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Parameter Ramping.xcplaygroundpage/Contents.swift
@@ -27,8 +27,8 @@ let toggling = AKPeriodicFunction(frequency: 2.66) {
     counter += 1
 }
 
-AudioKit.output = filter
-try AudioKit.start(withPeriodicFunctions: toggling)
+AKManager.output = filter
+try AKManager.start(withPeriodicFunctions: toggling)
 
 noise.start()
 toggling.start()

--- a/Xcode/Playgrounds/Basics.playground/Pages/Playgrounds to Production.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Playgrounds to Production.xcplaygroundpage/Contents.swift
@@ -19,16 +19,16 @@ import AudioKit
 //: In a playground, you don't have to worry about whether a node is retained, so you can
 //: just write:
 let oscillator = AKOscillator()
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 //: But if you did the same type of thing in a project:
 class BadAudioEngine {
     init() {
         let oscillator = AKOscillator()
-        AudioKit.output = oscillator
+        AKManager.output = oscillator
         do {
-            try AudioKit.start()
+            try AKManager.start()
         } catch {
             AKLog("AudioKit did not start")
         }
@@ -42,9 +42,9 @@ class AudioEngine {
 
     init() {
         oscillator = AKOscillator()
-        AudioKit.output = oscillator
+        AKManager.output = oscillator
         do {
-            try AudioKit.start()
+            try AKManager.start()
         } catch {
             AKLog("AudioKit did not start")
         }
@@ -55,12 +55,12 @@ class AudioEngine {
 //:
 //: In AudioKit playgrounds, failable initializers are just one line:
 let file = try AKAudioFile()
-try AudioKit.start()
+try AKManager.start()
 
 //: In production code, this would need to be wrapped in a do-catch block
 do {
     let file = try AKAudioFile(readFileName: "drumloop.wav")
-    try AudioKit.start()
+    try AKManager.start()
 } catch {
     AKLog("File Not Found or AudioKit did not start")
 }

--- a/Xcode/Playgrounds/Basics.playground/Pages/Splitting Nodes.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Splitting Nodes.xcplaygroundpage/Contents.swift
@@ -28,8 +28,8 @@ delay.dryWetMix = 1
 //: don't have that property by default
 let mixer = AKMixer(player, delay)
 
-AudioKit.output = mixer
-try AudioKit.start()
+AKManager.output = mixer
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Basics.playground/Pages/Stereo Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Stereo Operation.xcplaygroundpage/Contents.swift
@@ -21,8 +21,8 @@ let generator = AKOperationGenerator(channelCount: 2) { _ in
     return [leftOutput, rightOutput]
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 generator.start()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Basics.playground/Pages/Stereo Panning.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Stereo Panning.xcplaygroundpage/Contents.swift
@@ -25,8 +25,8 @@ let timer = AKPeriodicFunction(every: timeStep) {
     time += timeStep
 }
 
-AudioKit.output = panner
-try AudioKit.start(withPeriodicFunctions: timer)
+AKManager.output = panner
+try AKManager.start(withPeriodicFunctions: timer)
 
 player.play()
 timer.start()

--- a/Xcode/Playgrounds/Basics.playground/Pages/Using Functions Part 2.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Using Functions Part 2.xcplaygroundpage/Contents.swift
@@ -27,8 +27,8 @@ let generator = AKOperationGenerator { _ in
     return mixer(instruments, reverb, balance: 0.4)
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 
 generator.start()
 

--- a/Xcode/Playgrounds/Basics.playground/Pages/Using Functions.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Basics.playground/Pages/Using Functions.xcplaygroundpage/Contents.swift
@@ -22,8 +22,8 @@ let generator = AKOperationGenerator { _ in
     return (drone1 + drone2 + drone3) / 3
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 
 generator.start()
 

--- a/Xcode/Playgrounds/Basics.playground/contents.xcplayground
+++ b/Xcode/Playgrounds/Basics.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos' display-mode='rendered' executeOnSourceChanges='false' last-migration='0800'>
+<playground version='6.0' target-platform='macos' display-mode='rendered' buildActiveScheme='true' last-migration='0800'>
     <pages>
         <page name='Table Of Contents'/>
         <page name='Introduction and Hello World'/>

--- a/Xcode/Playgrounds/Effects.playground/Pages/3D Panner.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/3D Panner.xcplaygroundpage/Contents.swift
@@ -9,8 +9,8 @@ player.looping = true
 
 let panner = AK3DPanner(player)
 
-AudioKit.output = panner
-try AudioKit.start()
+AKManager.output = panner
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/ADC 2018.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/ADC 2018.xcplaygroundpage/Contents.swift
@@ -26,8 +26,8 @@ let micCopy1 = AKBooster(mic)
 let micCopy2 = AKBooster(mic)
 let micCopy3 = AKBooster(mic)
 
-AudioKit.output = AKStereoFieldLimiter(reverbMixer)
-try AudioKit.start()
+AKManager.output = AKStereoFieldLimiter(reverbMixer)
+try AKManager.start()
 
 //: User Interface
 import AudioKitUI

--- a/Xcode/Playgrounds/Effects.playground/Pages/Auto Wah Wah.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Auto Wah Wah.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ var wah = AKAutoWah(player)
 wah.wah = 1
 wah.amplitude = 1
 
-AudioKit.output = wah
-try AudioKit.start()
+AKManager.output = wah
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/AutoPanner.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/AutoPanner.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ let effect = AKAutoPanner(osc)
 
 effect.depth = 1
 effect.frequency = 1
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 //player.play()
 osc.start()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/AutoWah Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/AutoWah Operation.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ let effect = AKOperationEffect(player) { player, _ in
     return player.autoWah(wah: wahAmount, amplitude: 0.6)
 }
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Effects.playground/Pages/Bit Crush Effect.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Bit Crush Effect.xcplaygroundpage/Contents.swift
@@ -20,8 +20,8 @@ var bitcrusher = AKBitCrusher(player)
 bitcrusher.bitDepth = 16
 bitcrusher.sampleRate = 3_333
 
-AudioKit.output = bitcrusher
-try AudioKit.start()
+AKManager.output = bitcrusher
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Bit Crush Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Bit Crush Operation.xcplaygroundpage/Contents.swift
@@ -24,8 +24,8 @@ let effect = AKOperationEffect(player) { input, parameters in
 }
 effect.parameters = [22_050, 0, 16, 0, 1]
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 class LiveView: AKLiveViewController {

--- a/Xcode/Playgrounds/Effects.playground/Pages/Chorus.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Chorus.xcplaygroundpage/Contents.swift
@@ -10,8 +10,8 @@ player.looping = true
 
 var chorus = AKChorus(player)
 
-AudioKit.output = chorus
-try AudioKit.start()
+AKManager.output = chorus
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Clipper.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Clipper.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ player.looping = true
 var clipper = AKClipper(player)
 clipper.limit = 0.1
 
-AudioKit.output = clipper
-try AudioKit.start()
+AKManager.output = clipper
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Comb Filter Reverb.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Comb Filter Reverb.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ player.looping = true
 var filter = AKCombFilterReverb(player, loopDuration: 0.1)
 filter.reverbDuration = 1
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Compressor.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Compressor.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ player.looping = true
 
 var compressor = AKCompressor(player)
 
-AudioKit.output = compressor
-try AudioKit.start()
+AKManager.output = compressor
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Convolution.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Convolution.xcplaygroundpage/Contents.swift
@@ -30,8 +30,8 @@ if let stairwell = bundle.url(forResource: "Impulse Responses/stairwell", withEx
 mixer = AKDryWetMixer(stairwellConvolution, dishConvolution, balance: 0.5)
 dryWetMixer = AKDryWetMixer(player, mixer, balance: 0.5)
 
-AudioKit.output = dryWetMixer
-try AudioKit.start()
+AKManager.output = dryWetMixer
+try AKManager.start()
 
 stairwellConvolution.start()
 dishConvolution.start()

--- a/Xcode/Playgrounds/Effects.playground/Pages/Costello Reverb Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Costello Reverb Operation.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ let effect = AKOperationEffect(player) { player, _ in
         cutoffFrequency: 10_000)
 }
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 //: User Interface

--- a/Xcode/Playgrounds/Effects.playground/Pages/Costello Reverb.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Costello Reverb.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ var reverb = AKCostelloReverb(player)
 reverb.cutoffFrequency = 9_900 // Hz
 reverb.feedback = 0.92
 
-AudioKit.output = reverb
-try AudioKit.start()
+AKManager.output = reverb
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Decimator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Decimator.xcplaygroundpage/Contents.swift
@@ -16,8 +16,8 @@ decimator.decimation = 0.5 // Normalized Value 0 - 1
 decimator.rounding = 0.5 // Normalized Value 0 - 1
 decimator.mix = 0.5 // Normalized Value 0 - 1
 
-AudioKit.output = decimator
-try AudioKit.start()
+AKManager.output = decimator
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Delay.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Delay.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ delay.time = 0.01 // seconds
 delay.feedback = 0.9 // Normalized Value 0 - 1
 delay.dryWetMix = 0.6 // Normalized Value 0 - 1
 
-AudioKit.output = delay
-try AudioKit.start()
+AKManager.output = delay
+try AKManager.start()
 player.play()
 
 class LiveView: AKLiveViewController {

--- a/Xcode/Playgrounds/Effects.playground/Pages/Distortion.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Distortion.xcplaygroundpage/Contents.swift
@@ -20,8 +20,8 @@ distortion.polynomialMix = 0.5
 distortion.softClipGain = -6
 distortion.finalMix = 0.5
 
-AudioKit.output = AKBooster(distortion, gain: 0.1)
-try AudioKit.start()
+AKManager.output = AKBooster(distortion, gain: 0.1)
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/DynaRage Tube Compressor.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/DynaRage Tube Compressor.xcplaygroundpage/Contents.swift
@@ -10,8 +10,8 @@ player.looping = true
 
 var effect = AKDynaRageCompressor(player)
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Dynamics Processor.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Dynamics Processor.xcplaygroundpage/Contents.swift
@@ -20,8 +20,8 @@ effect.attackDuration
 effect.releaseDuration
 effect.masterGain
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Expander.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Expander.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ player.looping = true
 
 var expander = AKExpander(player)
 
-AudioKit.output = expander
-try AudioKit.start()
+AKManager.output = expander
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Fatten Effect.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Fatten Effect.xcplaygroundpage/Contents.swift
@@ -19,8 +19,8 @@ let fatten = AKOperationEffect(player) { input, parameters in
     return AKStereoOperation(fatten)
 }
 
-AudioKit.output = fatten
-try AudioKit.start()
+AKManager.output = fatten
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Filter Section Example.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Filter Section Example.xcplaygroundpage/Contents.swift
@@ -22,8 +22,8 @@ let filterSectionEffect = AKOperationEffect(player) { player, _ in
     return player.moogLadderFilter(cutoffFrequency: lfo + cutoffFrequency,
                                    resonance: resonance)
 }
-AudioKit.output = filterSectionEffect
-try AudioKit.start()
+AKManager.output = filterSectionEffect
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Flanger.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Flanger.xcplaygroundpage/Contents.swift
@@ -10,9 +10,9 @@ player.looping = true
 
 var flanger = AKFlanger(player)
 
-AudioKit.output = flanger
+AKManager.output = flanger
 
-try AudioKit.start()
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Flat Frequency Response Reverb Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Flat Frequency Response Reverb Operation.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ let effect = AKOperationEffect(player) { player, _ in
     return player.reverberateWithFlatFrequencyResponse(reverbDuration: duration, loopDuration: 0.1)
 }
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Effects.playground/Pages/Flat Frequency Response Reverb.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Flat Frequency Response Reverb.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ player.looping = true
 var reverb = AKFlatFrequencyResponseReverb(player, loopDuration: 0.1)
 reverb.reverbDuration = 1
 
-AudioKit.output = reverb
-try AudioKit.start()
+AKManager.output = reverb
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Graphic Equalizer.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Graphic Equalizer.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ let filterBand5 = AKEqualizerFilter(filterBand4, centerFrequency: 250, bandwidth
 let filterBand6 = AKEqualizerFilter(filterBand5, centerFrequency: 500, bandwidth: 562, gain: 1.0)
 let filterBand7 = AKEqualizerFilter(filterBand6, centerFrequency: 1_000, bandwidth: 1_112, gain: 1.0)
 
-AudioKit.output = filterBand7
-try AudioKit.start()
+AKManager.output = filterBand7
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Multi-tap Delay.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Multi-tap Delay.xcplaygroundpage/Contents.swift
@@ -28,8 +28,8 @@ func multitapDelay(_ input: AKNode?, times: [Double], gains: [Double]) -> AKMixe
     return mix
 }
 
-AudioKit.output = multitapDelay(player, times: [0.1, 0.2, 0.4], gains: [0.5, 2.0, 0.5])
-try AudioKit.start()
+AKManager.output = multitapDelay(player, times: [0.1, 0.2, 0.4], gains: [0.5, 2.0, 0.5])
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Effects.playground/Pages/MultiDelay Example.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/MultiDelay Example.xcplaygroundpage/Contents.swift
@@ -40,8 +40,8 @@ let delayPannedRight = AKPanner(rightDelay, pan: 1)
 
 let mix = AKMixer(delayPannedLeft, delayPannedRight)
 
-AudioKit.output = mix
-try AudioKit.start()
+AKManager.output = mix
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Effects.playground/Pages/Peak Limiter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Peak Limiter.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ peakLimiter.attackDuration = 0.001 // Secs
 peakLimiter.decayDuration = 0.01 // Secs
 peakLimiter.preGain = 10 // dB
 
-AudioKit.output = peakLimiter
-try AudioKit.start()
+AKManager.output = peakLimiter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Phaser.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Phaser.xcplaygroundpage/Contents.swift
@@ -10,8 +10,8 @@ player.looping = true
 
 var phaser = AKPhaser(player)
 
-AudioKit.output = phaser
-try AudioKit.start()
+AKManager.output = phaser
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Pitch Shift Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Pitch Shift Operation.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ let effect = AKOperationEffect(player) { player, parameters in
 }
 effect.parameters = [0, 7, 3]
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 import AudioKitUI

--- a/Xcode/Playgrounds/Effects.playground/Pages/Pitch Shifter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Pitch Shifter.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ player.looping = true
 
 var pitchshifter = AKPitchShifter(player)
 
-AudioKit.output = pitchshifter
-try AudioKit.start()
+AKManager.output = pitchshifter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Reverb.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Reverb.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ player.looping = true
 var reverb = AKReverb(player)
 reverb.dryWetMix = 0.5
 
-AudioKit.output = reverb
-try AudioKit.start()
+AKManager.output = reverb
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Rhino Guitar Processor.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Rhino Guitar Processor.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ do {
     player.looping = true
     rhino = AKRhinoGuitarProcessor(player)
     let reverb = AKReverb(rhino)
-    AudioKit.output = AKMixer(reverb, rhino)
-    try AudioKit.start()
+    AKManager.output = AKMixer(reverb, rhino)
+    try AKManager.start()
     player.play()
 } catch let error as NSError {
     AKLog(error.localizedDescription)

--- a/Xcode/Playgrounds/Effects.playground/Pages/Ring Modulator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Ring Modulator.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ ringModulator.frequency2 = 660 // Hz
 ringModulator.balance = 0.5
 ringModulator.mix = 0.5
 
-AudioKit.output = ringModulator
-try AudioKit.start()
+AKManager.output = ringModulator
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Smooth Delay Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Smooth Delay Operation.xcplaygroundpage/Contents.swift
@@ -18,8 +18,8 @@ let effect = AKOperationEffect(player) { player, parameters in
 }
 effect.parameters = [0.1, 0.7]
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 import AudioKitUI

--- a/Xcode/Playgrounds/Effects.playground/Pages/Sporth Based Effect.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Sporth Based Effect.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ let sporth = "\(input) 15 200 7.0 8.0 10000 315 0 1500 0 1 0 zitarev"
 
 let effect = AKOperationEffect(player, sporth: sporth)
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Sporth Custom Effect.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Sporth Custom Effect.xcplaygroundpage/Contents.swift
@@ -25,8 +25,8 @@ let sporth = "(\(input) ((0 p) 40 (_throttle f)) 1000 100 pshift) dup"
 
 let effect = AKOperationEffect(player, sporth: sporth, customUgens: [throttleUgen])
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Stereo Delay Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Stereo Delay Operation.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ let effect = AKOperationEffect(player, channelCount: 2) { _, parameters in
 }
 effect.parameters = [0.2, 0.5, 0.01, 0.9]
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 //: User Interface

--- a/Xcode/Playgrounds/Effects.playground/Pages/Stereo Field Limiter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Stereo Field Limiter.xcplaygroundpage/Contents.swift
@@ -10,8 +10,8 @@ player.looping = true
 
 var limitedOutput = AKStereoFieldLimiter(player)
 
-AudioKit.output = limitedOutput
-try AudioKit.start()
+AKManager.output = limitedOutput
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/String Resonator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/String Resonator.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ stringResonator.feedback = 0.9
 stringResonator.fundamentalFrequency = 1_000
 stringResonator.rampDuration = 0.1
 
-AudioKit.output = stringResonator
-try AudioKit.start()
+AKManager.output = stringResonator
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Tanh Distortion.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Tanh Distortion.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ distortion.postgain = 1.0
 distortion.positiveShapeParameter = 1.0
 distortion.negativeShapeParameter = 1.0
 
-AudioKit.output = distortion
-try AudioKit.start()
+AKManager.output = distortion
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Effects.playground/Pages/Tremolo.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Tremolo.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ var tremolo = AKTremolo(player, waveform: AKTable(.positiveSine))
 tremolo.depth = 0.5
 tremolo.frequency = 8
 
-AudioKit.output = tremolo
-try AudioKit.start()
+AKManager.output = tremolo
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Effects.playground/Pages/Variable Delay Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Variable Delay Operation.xcplaygroundpage/Contents.swift
@@ -19,8 +19,8 @@ let effect = AKOperationEffect(player) { player, parameters in
 }
 effect.parameters = [0.2, 0.3, 0.21]
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 //: User Interface

--- a/Xcode/Playgrounds/Effects.playground/Pages/Variable Delay.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Effects.playground/Pages/Variable Delay.xcplaygroundpage/Contents.swift
@@ -9,9 +9,9 @@ player.looping = true
 
 var delay = AKVariableDelay(player)
 delay.rampDuration = 0.2
-AudioKit.output = AKMixer(player, delay)
+AKManager.output = AKMixer(player, delay)
 
-try AudioKit.start()
+try AKManager.start()
 
 import AudioKitUI
 

--- a/Xcode/Playgrounds/Filters.playground/Pages/Band Pass Butterworth Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Band Pass Butterworth Filter.xcplaygroundpage/Contents.swift
@@ -17,8 +17,8 @@ var filter = AKBandPassButterworthFilter(player)
 filter.centerFrequency = 5_000 // Hz
 filter.bandwidth = 600 // Cents
 filter.rampDuration = 1.0
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Band Reject Butterworth Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Band Reject Butterworth Filter.xcplaygroundpage/Contents.swift
@@ -10,8 +10,8 @@ var filter = AKBandRejectButterworthFilter(player)
 filter.centerFrequency = 5_000 // Hz
 filter.bandwidth = 600  // Cents
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Formant Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Formant Filter.xcplaygroundpage/Contents.swift
@@ -8,8 +8,8 @@ osc.pulseWidth = 0.1
 
 var filter = AKFormantFilter(osc)
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 osc.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/High Pass Butterworth Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/High Pass Butterworth Filter.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ player.looping = true
 var filter = AKHighPassButterworthFilter(player)
 filter.cutoffFrequency = 6_900 // Hz
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/High Pass Filter Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/High Pass Filter Operation.xcplaygroundpage/Contents.swift
@@ -22,8 +22,8 @@ let filteredPlayer = AKOperationEffect(player) { player, _ in
 
 //: Mixdown and playback
 let mixer = AKDryWetMixer(filteredNoise, filteredPlayer, balance: 0.5)
-AudioKit.output = mixer
-try AudioKit.start()
+AKManager.output = mixer
+try AKManager.start()
 
 whiteNoise.start()
 player.play()

--- a/Xcode/Playgrounds/Filters.playground/Pages/High Pass Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/High Pass Filter.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ var filter = AKHighPassFilter(player)
 filter.cutoffFrequency = 6_900 // Hz
 filter.resonance = 0 // dB
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/High Shelf Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/High Shelf Filter.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ var filter = AKHighShelfFilter(player)
 filter.cutoffFrequency = 10_000 // Hz
 filter.gain = 0 // dB
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Korg Low Pass Filter Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Korg Low Pass Filter Operation.xcplaygroundpage/Contents.swift
@@ -24,8 +24,8 @@ let filteredPlayer = AKOperationEffect(player) { player, _ in
 
 //: Mixdown and playback
 let mixer = AKDryWetMixer(filteredNoise, filteredPlayer, balance: 0.5)
-AudioKit.output = mixer
-try AudioKit.start()
+AKManager.output = mixer
+try AKManager.start()
 
 whiteNoise.start()
 player.play()

--- a/Xcode/Playgrounds/Filters.playground/Pages/Korg Low Pass Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Korg Low Pass Filter.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ player.looping = true
 
 var filter = AKKorgLowPassFilter(player)
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Low Pass Butterworth Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Low Pass Butterworth Filter.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ player.looping = true
 var filter = AKLowPassButterworthFilter(player)
 filter.cutoffFrequency = 500 // Hz
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Low Pass Filter Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Low Pass Filter Operation.xcplaygroundpage/Contents.swift
@@ -23,8 +23,8 @@ let filteredPlayer = AKOperationEffect(player) { player, _ in
 
 //: Mixdown and playback
 let mixer = AKDryWetMixer(filteredNoise, filteredPlayer, balance: 0.5)
-AudioKit.output = mixer
-try AudioKit.start()
+AKManager.output = mixer
+try AKManager.start()
 
 whiteNoise.start()
 player.play()

--- a/Xcode/Playgrounds/Filters.playground/Pages/Low Pass Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Low Pass Filter.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ var filter = AKLowPassFilter(player)
 filter.cutoffFrequency = 6_900 // Hz
 filter.resonance = 0 // dB
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Low Shelf Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Low Shelf Filter.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ var filter = AKLowShelfFilter(player)
 filter.cutoffFrequency = 80 // Hz
 filter.gain = 0 // dB
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Modal Resonance Filter Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Modal Resonance Filter Operation.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ let effect = AKOperationEffect(player) { player, _ in
     return player.modalResonanceFilter(frequency: frequency, qualityFactor: 50) * 0.2
 }
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Filters.playground/Pages/Modal Resonance Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Modal Resonance Filter.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ filter.frequency = 300 // Hz
 filter.qualityFactor = 20
 
 let balancedOutput = AKBalancer(filter, comparator: player)
-AudioKit.output = balancedOutput
-try AudioKit.start()
+AKManager.output = balancedOutput
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Filters.playground/Pages/Moog Ladder Filter Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Moog Ladder Filter Operation.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ let effect = AKOperationEffect(player) { player, _ in
     return player.moogLadderFilter(cutoffFrequency: frequency, resonance: resonance) * 3
 }
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Filters.playground/Pages/Moog Ladder Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Moog Ladder Filter.xcplaygroundpage/Contents.swift
@@ -20,8 +20,8 @@ var moogLadder = AKMoogLadder(player)
 moogLadder.cutoffFrequency = 300 // Hz
 moogLadder.resonance = 0.6
 
-AudioKit.output = moogLadder
-try AudioKit.start()
+AKManager.output = moogLadder
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Filters.playground/Pages/Resonant Filter Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Resonant Filter Operation.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ let effect = AKOperationEffect(player) { player, _ in
     return player.resonantFilter(frequency: frequency, bandwidth: bandwidth) * 0.1
 }
 
-AudioKit.output = effect
-try AudioKit.start()
+AKManager.output = effect
+try AKManager.start()
 player.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Filters.playground/Pages/Resonant Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Resonant Filter.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ var filter = AKResonantFilter(player)
 filter.frequency = 5_000 // Hz
 filter.bandwidth = 600  // Cents
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Filters.playground/Pages/Roland TB-303 Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Roland TB-303 Filter.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ var filter = AKRolandTB303Filter(player)
 filter.cutoffFrequency = 1_350
 filter.resonance = 0.8
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 player.play()
 
 var time = 0.0

--- a/Xcode/Playgrounds/Filters.playground/Pages/Three-Pole Low Pass Filter.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Three-Pole Low Pass Filter.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ filter.cutoffFrequency = 300 // Hz
 filter.resonance = 0.6
 filter.rampDuration = 0.1
 
-AudioKit.output = filter
-try AudioKit.start()
+AKManager.output = filter
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Filters.playground/Pages/Tone and Tone Complement Filters.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Filters.playground/Pages/Tone and Tone Complement Filters.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ player.looping = true
 var toneFilter = AKToneFilter(player)
 var toneComplement = AKToneComplementFilter(toneFilter)
 
-AudioKit.output = toneComplement
-try AudioKit.start()
+AKManager.output = toneComplement
+try AKManager.start()
 
 player.play()
 

--- a/Xcode/Playgrounds/Playback.playground/Pages/Audio Player.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Audio Player.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ if let mixloop = try? AKAudioFile(readFileName: "mixloop.wav") {
     player = AKPlayer(audioFile: mixloop)
     player.completionHandler = { AKLog("completion callback has been triggered!") }
     player.isLooping = true
-    AudioKit.output = player
-    try AudioKit.start()
+    AKManager.output = player
+    try AKManager.start()
     player.play()
 }
 //: Don't forget to show the "debug area" to see what messages are printed by the player

--- a/Xcode/Playgrounds/Playback.playground/Pages/Callback Instrument.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Callback Instrument.xcplaygroundpage/Contents.swift
@@ -37,8 +37,8 @@ clickTrack?.setLoopInfo(AKDuration(beats: 1.0), numberOfLoops: 10)
 sequencer.setTempo(tempo)
 
 // We must link the clock's output to AudioKit (even if we don't need the sound)
-//AudioKit.output = callbacker
-//try AudioKit.start()
+//AKManager.output = callbacker
+//try AKManager.start()
 
 //: Create a simple user interface
 import AudioKitUI

--- a/Xcode/Playgrounds/Playback.playground/Pages/Drum Sequencer.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Drum Sequencer.xcplaygroundpage/Contents.swift
@@ -5,8 +5,8 @@ import AudioKit
 
 let drums = AKMIDISampler()
 
-AudioKit.output = drums
-try AudioKit.start()
+AKManager.output = drums
+try AKManager.start()
 
 let bassDrumFile = try AKAudioFile(readFileName: "Samples/Drums/bass_drum_C1.wav")
 let clapFile = try AKAudioFile(readFileName: "Samples/Drums/clap_D#1.wav")

--- a/Xcode/Playgrounds/Playback.playground/Pages/Drums.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Drums.xcplaygroundpage/Contents.swift
@@ -5,8 +5,8 @@ import AudioKit
 
 let drums = AKAppleSampler()
 
-AudioKit.output = drums
-try AudioKit.start()
+AKManager.output = drums
+try AKManager.start()
 
 let bassDrumFile = try AKAudioFile(readFileName: "Samples/Drums/bass_drum_C1.wav")
 let clapFile = try AKAudioFile(readFileName: "Samples/Drums/clap_D#1.wav")

--- a/Xcode/Playgrounds/Playback.playground/Pages/Editing Audio Files.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Editing Audio Files.xcplaygroundpage/Contents.swift
@@ -67,8 +67,8 @@ for i in 0..<16 {
 let sequencePlayer = try AKAudioPlayer(file: sequence)
 sequencePlayer.looping = true
 
-AudioKit.output = sequencePlayer
-try AudioKit.start()
+AKManager.output = sequencePlayer
+try AKManager.start()
 sequencePlayer.play()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Playback.playground/Pages/Exporting files.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Exporting files.xcplaygroundpage/Contents.swift
@@ -9,8 +9,8 @@ let mixloop = try AKAudioFile(readFileName: "mixloop.wav")
 //: Export will be done asynchronously. So you can play some music while exporting
 
 let player = try AKAudioPlayer(file: mixloop)
-AudioKit.output = player
-try AudioKit.start()
+AKManager.output = player
+try AKManager.start()
 player.play()
 
 //: You need a callback that will be triggered as soon as Export has been completed.

--- a/Xcode/Playgrounds/Playback.playground/Pages/MIDI Chord Generator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/MIDI Chord Generator.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ reverb.loadFactoryPreset(.largeRoom)
 var mixer = AKMixer(reverb)
 mixer.volume = 5.0
 
-AudioKit.output = mixer
-try AudioKit.start()
+AKManager.output = mixer
+try AKManager.start()
 
 enum Key {
     case C, Db, D, Eb, E, F, Gb, G, Ab, A, Bb, B

--- a/Xcode/Playgrounds/Playback.playground/Pages/MIDI Scale Quantizer.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/MIDI Scale Quantizer.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ reverb.loadFactoryPreset(.largeRoom)
 var mixer = AKMixer(reverb)
 mixer.volume = 5.0
 
-AudioKit.output = mixer
-try AudioKit.start()
+AKManager.output = mixer
+try AKManager.start()
 
 enum Key {
     case C, Db, D, Eb, E, F, Gb, G, Ab, A, Bb, B

--- a/Xcode/Playgrounds/Playback.playground/Pages/Phase-Locked Vocoder.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Phase-Locked Vocoder.xcplaygroundpage/Contents.swift
@@ -6,8 +6,8 @@ import AudioKit
 let file = try AKAudioFile(readFileName: "guitarloop.wav")
 let phaseLockedVocoder = AKPhaseLockedVocoder(file: file)
 
-AudioKit.output = phaseLockedVocoder
-try AudioKit.start()
+AKManager.output = phaseLockedVocoder
+try AKManager.start()
 phaseLockedVocoder.start()
 phaseLockedVocoder.amplitude = 1
 phaseLockedVocoder.pitchRatio = 1

--- a/Xcode/Playgrounds/Playback.playground/Pages/Playback Speed.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Playback Speed.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ player.looping = true
 var variSpeed = AKVariSpeed(player)
 variSpeed.rate = 2.0
 
-AudioKit.output = variSpeed
-try AudioKit.start()
+AKManager.output = variSpeed
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Playback.playground/Pages/Processing Audio File Asynchronously.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Processing Audio File Asynchronously.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ var piano = try AKAudioFile(readFileName: "poney.mp3")
 let player = try AKAudioPlayer(file: piano)
 player.looping = true
 
-AudioKit.output = player
-try AudioKit.start()
+AKManager.output = player
+try AKManager.start()
 player.start()
 
 //: While the piano is playing, we will process the file in background. AKAudioFile has a private ProcessFactory

--- a/Xcode/Playgrounds/Playback.playground/Pages/Reading and Writing Audio Files.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Reading and Writing Audio Files.xcplaygroundpage/Contents.swift
@@ -55,8 +55,8 @@ drumloop.exportAsynchronously(name: "exported.m4a",
 
             AKLog(successfulFile.fileNamePlusExtension)
             let player = try! AKAudioPlayer(file: successfulFile)
-            AudioKit.output = player
-            try! AudioKit.start()
+            AKManager.output = player
+            try! AKManager.start()
             player.play()
         }
 

--- a/Xcode/Playgrounds/Playback.playground/Pages/Recording Nodes.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Recording Nodes.xcplaygroundpage/Contents.swift
@@ -31,9 +31,9 @@ let mixer = AKMixer(player, reverb)
 //: node to "reverb" if you prefer to record a "wet" oscillator...
 let recorder = try AKNodeRecorder(node: mixer)
 
-AudioKit.output = mixer
+AKManager.output = mixer
 
-try AudioKit.start()
+try AKManager.start()
 
 //: Build our User interface
 import AudioKitUI

--- a/Xcode/Playgrounds/Playback.playground/Pages/Sample Player.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Sample Player.xcplaygroundpage/Contents.swift
@@ -10,8 +10,8 @@ let samplePlayer = AKSamplePlayer(file: file) {
     AKLog("Playback completed.")
 }
 
-AudioKit.output = samplePlayer
-try AudioKit.start()
+AKManager.output = samplePlayer
+try AKManager.start()
 
 import AudioKitUI
 

--- a/Xcode/Playgrounds/Playback.playground/Pages/Sampler.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Sampler.xcplaygroundpage/Contents.swift
@@ -20,8 +20,8 @@ reverb.loadFactoryPreset(.largeRoom)
 var mixer = AKMixer(reverb)
 mixer.volume = 5.0
 
-AudioKit.output = mixer
-try AudioKit.start()
+AKManager.output = mixer
+try AKManager.start()
 
 //: This is a loop to send a random note to the sampler
 AKPlaygroundLoop(every: pulse) {

--- a/Xcode/Playgrounds/Playback.playground/Pages/Sequencer.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Sequencer.xcplaygroundpage/Contents.swift
@@ -15,7 +15,7 @@ var mixer = AKMixer(piano, bell)
 let reverb = AKCostelloReverb(mixer)
 
 let dryWetMixer = AKDryWetMixer(mixer, reverb, balance: 0.2)
-AudioKit.output = dryWetMixer
+AKManager.output = dryWetMixer
 
 //: Create the sequencer after AudioKit's output has been set
 //: Load in a midi file, and set the sequencer to the main audiokit engine
@@ -26,7 +26,7 @@ sequencer.setLength(AKDuration(beats: 4))
 sequencer.enableLooping()
 sequencer.setGlobalMIDIOutput(piano.midiIn)
 
-try AudioKit.start()
+try AKManager.start()
 sequencer.play()
 
 //: Set up a basic UI for setting outputs of tracks

--- a/Xcode/Playgrounds/Playback.playground/Pages/Time Stretching and Pitch Shifting.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Playback.playground/Pages/Time Stretching and Pitch Shifting.xcplaygroundpage/Contents.swift
@@ -15,8 +15,8 @@ timePitch.rate = 2.0
 timePitch.pitch = -400.0
 timePitch.overlap = 8.0
 
-AudioKit.output = timePitch
-try AudioKit.start()
+AKManager.output = timePitch
+try AKManager.start()
 player.play()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Amplitude Envelope.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Amplitude Envelope.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ import AudioKit
 
 var fmWithADSR = AKOscillatorBank()
 var amplitudeTracker = AKAmplitudeTracker(fmWithADSR)
-AudioKit.output = AKBooster(amplitudeTracker, gain: 5)
-try AudioKit.start()
+AKManager.output = AKBooster(amplitudeTracker, gain: 5)
+try AKManager.start()
 amplitudeTracker.start()
 
 //: User Interface Set up

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Clarinet.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Clarinet.xcplaygroundpage/Contents.swift
@@ -26,8 +26,8 @@ let performance = AKPeriodicFunction(frequency: playRate) {
     }
 }
 
-AudioKit.output = reverb
-try AudioKit.start(withPeriodicFunctions: performance)
+AKManager.output = reverb
+try AKManager.start(withPeriodicFunctions: performance)
 performance.start()
 
 PlaygroundPage.current.needsIndefiniteExecution = true

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Drawbar Organ.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Drawbar Organ.xcplaygroundpage/Contents.swift
@@ -6,8 +6,8 @@ import AudioKit
 import AudioKitUI
 
 var oscillator = AKOscillatorBank()
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 let noteCount = 9
 var amplitudes = [Double](repeating: 0.1, count: noteCount)

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Dripping Sounds.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Dripping Sounds.xcplaygroundpage/Contents.swift
@@ -16,8 +16,8 @@ let drips = AKPeriodicFunction(frequency: playRate) {
     drip.trigger()
 }
 
-AudioKit.output = AKBooster(reverb, gain: 0.4)
-try AudioKit.start(withPeriodicFunctions: drips)
+AKManager.output = AKBooster(reverb, gain: 0.4)
+try AKManager.start(withPeriodicFunctions: drips)
 drips.start()
 
 class LiveView: AKLiveViewController {

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Drum Synthesizers.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Drum Synthesizers.xcplaygroundpage/Contents.swift
@@ -32,8 +32,8 @@ let beats = AKPeriodicFunction(frequency: 5) {
     counter += 1
 }
 
-AudioKit.output = reverb
-try AudioKit.start(withPeriodicFunctions: beats)
+AKManager.output = reverb
+try AKManager.start(withPeriodicFunctions: beats)
 reverb.loadFactoryPreset(.mediumRoom)
 beats.start()
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/FM Oscillator Bank.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/FM Oscillator Bank.xcplaygroundpage/Contents.swift
@@ -8,8 +8,8 @@ import AudioKitUI
 
 let fmBank = AKFMOscillatorBank()
 
-AudioKit.output = fmBank
-try AudioKit.start()
+AKManager.output = fmBank
+try AKManager.start()
 
 class LiveView: AKLiveViewController, AKKeyboardDelegate {
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/FM Oscillator Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/FM Oscillator Operation.xcplaygroundpage/Contents.swift
@@ -29,8 +29,8 @@ let delay1 = AKDelay(generator, time: 0.01, feedback: 0.99, lowPassCutoff: 0, dr
 let delay2 = AKDelay(delay1, time: 0.1, feedback: 0.1, lowPassCutoff: 0, dryWetMix: 0.5)
 let reverb = AKReverb(delay2, dryWetMix: 0.5)
 
-AudioKit.output = reverb
-try AudioKit.start()
+AKManager.output = reverb
+try AKManager.start()
 
 generator.start()
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/FM Oscillator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/FM Oscillator.xcplaygroundpage/Contents.swift
@@ -9,8 +9,8 @@ import AudioKitUI
 var oscillator = AKFMOscillator()
 oscillator.amplitude = 0.1
 oscillator.rampDuration = 0.1
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 class LiveView: AKLiveViewController {
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Filter Envelope.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Filter Envelope.xcplaygroundpage/Contents.swift
@@ -53,8 +53,8 @@ let synth = AKOperationGenerator { _ in
         resonance: 0.9)
 }
 
-AudioKit.output = synth
-try AudioKit.start()
+AKManager.output = synth
+try AKManager.start()
 synth.parameters = [0, 1_000, 0] // Initialize the array
 synth.start()
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Flute.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Flute.xcplaygroundpage/Contents.swift
@@ -25,8 +25,8 @@ let performance = AKPeriodicFunction(frequency: playRate) {
     }
 }
 
-AudioKit.output = reverb
-try AudioKit.start(withPeriodicFunctions: performance)
+AKManager.output = reverb
+try AKManager.start(withPeriodicFunctions: performance)
 performance.start()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Mandolin.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Mandolin.xcplaygroundpage/Contents.swift
@@ -40,8 +40,8 @@ let performance = AKPeriodicFunction(frequency: playRate) {
     }
 }
 
-AudioKit.output = reverb
-try AudioKit.start(withPeriodicFunctions: performance)
+AKManager.output = reverb
+try AKManager.start(withPeriodicFunctions: performance)
 performance.start()
 
 import AudioKitUI

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Microtonality.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Microtonality.xcplaygroundpage/Contents.swift
@@ -119,8 +119,8 @@ let sequencerFunction = AKPeriodicFunction(frequency: playRate) {
 }
 
 // Start Audio
-AudioKit.output = mixer
-try AudioKit.start(withPeriodicFunctions: sequencerFunction)
+AKManager.output = mixer
+try AKManager.start(withPeriodicFunctions: sequencerFunction)
 sequencerFunction.start()
 
 import AudioKitUI

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Morphing Oscillator Bank.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Morphing Oscillator Bank.xcplaygroundpage/Contents.swift
@@ -5,8 +5,8 @@ import AudioKitUI
 
 let bank = AKMorphingOscillatorBank()
 
-AudioKit.output = bank
-try AudioKit.start()
+AKManager.output = bank
+try AKManager.start()
 
 class LiveView: AKLiveViewController, AKKeyboardDelegate {
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Morphing Oscillator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Morphing Oscillator.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ morph.frequency = 400
 morph.amplitude = 0.1
 morph.index = 0.8
 
-AudioKit.output = morph
-try AudioKit.start()
+AKManager.output = morph
+try AKManager.start()
 morph.start()
 
 class LiveView: AKLiveViewController {

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Noise Generators.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Noise Generators.xcplaygroundpage/Contents.swift
@@ -7,8 +7,8 @@ var brownian = AKBrownianNoise(amplitude: 0.2)
 var pink = AKPinkNoise(amplitude: 0.2)
 var white = AKWhiteNoise(amplitude: 0.1)
 
-AudioKit.output = AKMixer(brownian, pink, white)
-try AudioKit.start()
+AKManager.output = AKMixer(brownian, pink, white)
+try AKManager.start()
 
 brownian.start()
 pink.start()

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Noise Operations.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Noise Operations.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ let generator = AKOperationGenerator { _ in
     return noise.pan(lfo)
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 
 generator.start()
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Oscillator Bank.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Oscillator Bank.xcplaygroundpage/Contents.swift
@@ -7,8 +7,8 @@ let bank = AKOscillatorBank(waveform: AKTable(.sine),
                             attackDuration: 0.1,
                             releaseDuration: 0.1)
 
-AudioKit.output = bank
-try AudioKit.start()
+AKManager.output = bank
+try AKManager.start()
 
 class LiveView: AKLiveViewController, AKKeyboardDelegate {
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Oscillator Synth.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Oscillator Synth.xcplaygroundpage/Contents.swift
@@ -14,8 +14,8 @@ var currentMIDINote: MIDINoteNumber = 0
 var currentAmplitude = 0.1
 var currentRampDuration = 0.0
 
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 let playgroundWidth = 500
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Oscillator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Oscillator.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ let sawtooth = AKTable(.sawtooth, count: 256)
 //: Try changing the table to triangle, square, sine, or sawtooth.
 //: This will change the shape of the oscillator's waveform.
 var oscillator = AKOscillator(waveform: square)
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 var currentMIDINote: MIDINoteNumber = 0
 var currentAmplitude = 0.2

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/PWM Oscillator Bank.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/PWM Oscillator Bank.xcplaygroundpage/Contents.swift
@@ -5,8 +5,8 @@ import AudioKitUI
 
 let bank = AKPWMOscillatorBank(pulseWidth: 0.5)
 
-AudioKit.output = bank
-try AudioKit.start()
+AKManager.output = bank
+try AKManager.start()
 
 class LiveView: AKLiveViewController, AKKeyboardDelegate {
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/PWM Oscillator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/PWM Oscillator.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ var currentMIDINote: MIDINoteNumber = 0
 var currentAmplitude = 0.1
 var currentRampDuration = 0.0
 
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 let playgroundWidth = 500
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Pedestrians.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Pedestrians.xcplaygroundpage/Contents.swift
@@ -21,8 +21,8 @@ let generator = AKOperationGenerator { _ in
     return crossingSignal * 0.2
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 //: Activate the signal
 generator.start()
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Phase Distortion Oscillator Bank.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Phase Distortion Oscillator Bank.xcplaygroundpage/Contents.swift
@@ -5,8 +5,8 @@ import AudioKitUI
 
 let bank = AKPhaseDistortionOscillatorBank(waveform: AKTable(.square))
 
-AudioKit.output = bank
-try AudioKit.start()
+AKManager.output = bank
+try AKManager.start()
 
 class LiveView: AKLiveViewController, AKKeyboardDelegate {
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Phase Distortion Oscillator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Phase Distortion Oscillator.xcplaygroundpage/Contents.swift
@@ -9,8 +9,8 @@ oscillator.phaseDistortion = 0.0
 var currentAmplitude = 0.1
 var currentRampDuration = 0.0
 
-AudioKit.output = oscillator
-try AudioKit.start()
+AKManager.output = oscillator
+try AKManager.start()
 
 let playgroundWidth = 500
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Phasor Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Phasor Operation.xcplaygroundpage/Contents.swift
@@ -19,8 +19,8 @@ let generator = AKOperationGenerator { _ in
     return mixer(oscillator, reverb, balance: 0.6)
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 generator.start()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Plucked String Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Plucked String Operation.xcplaygroundpage/Contents.swift
@@ -35,8 +35,8 @@ let performance = AKPeriodicFunction(frequency: playRate) {
     }
 }
 
-AudioKit.output = reverb
-try AudioKit.start(withPeriodicFunctions: performance)
+AKManager.output = reverb
+try AKManager.start(withPeriodicFunctions: performance)
 pluckNode.start()
 performance.start()
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Plucked String.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Plucked String.xcplaygroundpage/Contents.swift
@@ -27,8 +27,8 @@ let performance = AKPeriodicFunction(frequency: playRate) {
     }
 }
 
-AudioKit.output = reverb
-try AudioKit.start(withPeriodicFunctions: performance)
+AKManager.output = reverb
+try AKManager.start(withPeriodicFunctions: performance)
 performance.start()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Sawtooth Wave Oscillator Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Sawtooth Wave Oscillator Operation.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ let generator = AKOperationGenerator { _ in
     return AKOperation.sawtoothWave(frequency: freq, amplitude: amp)
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 
 generator.start()
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Segment Operations.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Segment Operations.xcplaygroundpage/Contents.swift
@@ -31,8 +31,8 @@ delay.feedback = 0.8
 var reverb = AKReverb(delay)
 reverb.loadFactoryPreset(.largeHall)
 
-AudioKit.output = reverb
-try AudioKit.start()
+AKManager.output = reverb
+try AKManager.start()
 
 generator.parameters = [2.0]
 generator.start()

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Sporth Based Generator.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Sporth Based Generator.xcplaygroundpage/Contents.swift
@@ -5,8 +5,8 @@ import AudioKitPlaygrounds
 import AudioKit
 
 var generator = AKOperationGenerator(sporth: "")
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 //: User Interface Set up
 import AudioKitUI
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Telephone.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Telephone.xcplaygroundpage/Contents.swift
@@ -71,8 +71,8 @@ let keypad = AKOperationGenerator { parameters in
     return momentaryPress * 0.4
 }
 
-AudioKit.output = AKMixer(dialTone, ringing, busy, keypad)
-try AudioKit.start()
+AKManager.output = AKMixer(dialTone, ringing, busy, keypad)
+try AKManager.start()
 dialTone.start()
 
 keypad.start()

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Tubular Bells.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Tubular Bells.xcplaygroundpage/Contents.swift
@@ -26,8 +26,8 @@ let performance = AKPeriodicFunction(frequency: playRate) {
     }
 }
 
-AudioKit.output = reverb
-try AudioKit.start(withPeriodicFunctions: performance)
+AKManager.output = reverb
+try AKManager.start(withPeriodicFunctions: performance)
 performance.start()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Vocal Tract Operation.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Vocal Tract Operation.xcplaygroundpage/Contents.swift
@@ -20,8 +20,8 @@ let generator = AKOperationGenerator { _ in
                                   nasality: nasality)
 }
 
-AudioKit.output = generator
-try AudioKit.start()
+AKManager.output = generator
+try AKManager.start()
 generator.start()
 
 import PlaygroundSupport

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/Vocal Tract.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/Vocal Tract.xcplaygroundpage/Contents.swift
@@ -6,8 +6,8 @@ import AudioKitUI
 
 let voc = AKVocalTract()
 
-AudioKit.output = voc
-try AudioKit.start()
+AKManager.output = voc
+try AKManager.start()
 
 class LiveView: AKLiveViewController {
 

--- a/Xcode/Playgrounds/Synthesis.playground/Pages/XY Pad.xcplaygroundpage/Contents.swift
+++ b/Xcode/Playgrounds/Synthesis.playground/Pages/XY Pad.xcplaygroundpage/Contents.swift
@@ -11,8 +11,8 @@ delay.feedback = 0.3
 delay.time = 0.1
 let reverb = AKCostelloReverb(delay)
 let mix = AKDryWetMixer(delay, reverb, balance: 0.5)
-AudioKit.output = mix
-try AudioKit.start()
+AKManager.output = mix
+try AKManager.start()
 
 class TouchView: NSView {
     var (path, currentPath) = (NSBezierPath(), NSBezierPath())

--- a/Xcode/Podfile.lock
+++ b/Xcode/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AudioKit (4.10):
-    - AudioKit/Core (= 4.10)
-    - AudioKit/UI (= 4.10)
-  - AudioKit/Core (4.10)
-  - AudioKit/UI (4.10):
+  - AudioKit (4.11.2):
+    - AudioKit/Core (= 4.11.2)
+    - AudioKit/UI (= 4.11.2)
+  - AudioKit/Core (4.11.2)
+  - AudioKit/UI (4.11.2):
     - AudioKit/Core
 
 DEPENDENCIES:
@@ -14,7 +14,7 @@ SPEC REPOS:
     - AudioKit
 
 SPEC CHECKSUMS:
-  AudioKit: 37d31154cf4708146964f8eee757b1af732bd15e
+  AudioKit: 57cc61d708f085763a031e5c3f87adae21dc4b59
 
 PODFILE CHECKSUM: 8f9de1a78cd8c7c03a9d258dce699f7d26eff722
 


### PR DESCRIPTION
Bumping to 4.11.2, finding the following issue with AKSlider:

```
Fatal error: Use of unimplemented initializer 'init(property:value:range:taper:format:frame:callback:)' for class 'AudioKitUI.AKSlider'
```

But project can build for Playgrounds not using AKSlider